### PR TITLE
Token reservation logic

### DIFF
--- a/contracts/art-token/IArtToken.sol
+++ b/contracts/art-token/IArtToken.sol
@@ -35,6 +35,11 @@ interface IArtToken is IERC721 {
     function buy(BuyParams calldata params) external;
 
     /**
+     * @dev Returns true if the token is reserved.
+     */
+    function tokenReserved(uint256 tokenId) external view returns (bool);
+
+    /**
      * @dev The caller account is not authorized.
      */
     error ArtTokenUnauthorizedAccount(address account);
@@ -43,4 +48,9 @@ interface IArtToken is IERC721 {
      * @dev The token receiver is not valid.
      */
     error ArtTokenInvalidReceiver(address receiver);
+
+    /**
+     * @dev The token is reserved.
+     */
+    error ArtTokenReserved(uint256 tokenId);
 }

--- a/contracts/auction-house/AuctionHouseStorage.sol
+++ b/contracts/auction-house/AuctionHouseStorage.sol
@@ -18,6 +18,7 @@ library AuctionHouseStorage {
      */
     struct Layout {
         mapping(uint256 auctionId => IAuctionHouse.Auction) auctions;
+        mapping(uint256 tokenId => uint256 auctionId) tokenAuctionIds;
     }
 
     /**

--- a/contracts/auction-house/IAuctionHouse.sol
+++ b/contracts/auction-house/IAuctionHouse.sol
@@ -81,9 +81,24 @@ interface IAuctionHouse {
     function auction(uint256 auctionId) external view returns (Auction memory);
 
     /**
+     * @dev Returns true if an auction has reserved the token.
+     */
+    function tokenReserved(uint256 tokenId) external view returns (bool);
+
+    /**
      * @dev The auction end time is less than block time.
      */
     error AuctionHouseInvalidEndTime(uint256 endTime, uint256 blockTime);
+
+    /**
+     * @dev The token is reserved.
+     */
+    error AuctionHouseTokenReserved(uint256 tokenId);
+
+    /**
+     * @dev The auction id is zero.
+     */
+    error AuctionHouseZeroId();
 
     /**
      * @dev The token buyer must not exist.

--- a/contracts/utils/Deployer.sol
+++ b/contracts/utils/Deployer.sol
@@ -20,7 +20,7 @@ contract Deployer {
         );
 
         address artToken_ = _deployUpgradeable(
-            address(new ArtToken(admin, platform, auctionHouse, usdc)),
+            address(new ArtToken(admin, platform, AuctionHouse(auctionHouse), usdc)),
             proxyAdminOwner
         );
 

--- a/slither.db.json
+++ b/slither.db.json
@@ -5,728 +5,13 @@
                 "type": "variable",
                 "name": "admin",
                 "source_mapping": {
-                    "start": 1781,
-                    "length": 13,
-                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                    "filename_short": "contracts/art-token/ArtToken.sol",
-                    "is_dependency": false,
-                    "lines": [56],
-                    "starting_column": 11,
-                    "ending_column": 24
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 1769,
-                            "length": 222,
-                            "filename_relative": "contracts/art-token/ArtToken.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                            "filename_short": "contracts/art-token/ArtToken.sol",
-                            "is_dependency": false,
-                            "lines": [55, 56, 57, 58, 59, 60],
-                            "starting_column": 7,
-                            "ending_column": 21
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "ArtToken",
-                                "source_mapping": {
-                                    "start": 580,
-                                    "length": 4112,
-                                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                                    "filename_short": "contracts/art-token/ArtToken.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                                        45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-                                        75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-                                        90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-                                        104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                                        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
-                                        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138
-                                    ],
-                                    "starting_column": 89,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "constructor(address,address,address,IERC20)"
-                        }
-                    }
-                }
-            },
-            {
-                "type": "node",
-                "name": "ADMIN = admin",
-                "source_mapping": {
-                    "start": 1883,
+                    "start": 1868,
                     "length": 13,
                     "filename_relative": "contracts/art-token/ArtToken.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
                     "filename_short": "contracts/art-token/ArtToken.sol",
                     "is_dependency": false,
                     "lines": [57],
-                    "starting_column": 3,
-                    "ending_column": 16
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 1769,
-                            "length": 222,
-                            "filename_relative": "contracts/art-token/ArtToken.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                            "filename_short": "contracts/art-token/ArtToken.sol",
-                            "is_dependency": false,
-                            "lines": [55, 56, 57, 58, 59, 60],
-                            "starting_column": 7,
-                            "ending_column": 21
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "ArtToken",
-                                "source_mapping": {
-                                    "start": 580,
-                                    "length": 4112,
-                                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                                    "filename_short": "contracts/art-token/ArtToken.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                                        45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-                                        75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-                                        90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-                                        104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                                        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
-                                        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138
-                                    ],
-                                    "starting_column": 89,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "constructor(address,address,address,IERC20)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "ArtToken.constructor(address,address,address,IERC20).admin (contracts/art-token/ArtToken.sol#56) lacks a zero-check on :\n\t\t- ADMIN = admin (contracts/art-token/ArtToken.sol#57)\n",
-        "markdown": "[ArtToken.constructor(address,address,address,IERC20).admin](contracts/art-token/ArtToken.sol#L56) lacks a zero-check on :\n\t\t- [ADMIN = admin](contracts/art-token/ArtToken.sol#L57)\n",
-        "first_markdown_element": "contracts/art-token/ArtToken.sol#L56",
-        "id": "09c3ad2cc81dce5d3a5612601dae8cc5c2d3a24e901db94156f74934e1649310",
-        "check": "missing-zero-check",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "variable",
-                "name": "platform",
-                "source_mapping": {
-                    "start": 1796,
-                    "length": 16,
-                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                    "filename_short": "contracts/art-token/ArtToken.sol",
-                    "is_dependency": false,
-                    "lines": [56],
-                    "starting_column": 26,
-                    "ending_column": 42
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 1769,
-                            "length": 222,
-                            "filename_relative": "contracts/art-token/ArtToken.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                            "filename_short": "contracts/art-token/ArtToken.sol",
-                            "is_dependency": false,
-                            "lines": [55, 56, 57, 58, 59, 60],
-                            "starting_column": 7,
-                            "ending_column": 21
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "ArtToken",
-                                "source_mapping": {
-                                    "start": 580,
-                                    "length": 4112,
-                                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                                    "filename_short": "contracts/art-token/ArtToken.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                                        45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-                                        75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-                                        90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-                                        104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                                        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
-                                        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138
-                                    ],
-                                    "starting_column": 89,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "constructor(address,address,address,IERC20)"
-                        }
-                    }
-                }
-            },
-            {
-                "type": "node",
-                "name": "PLATFORM = platform",
-                "source_mapping": {
-                    "start": 1906,
-                    "length": 19,
-                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                    "filename_short": "contracts/art-token/ArtToken.sol",
-                    "is_dependency": false,
-                    "lines": [58],
-                    "starting_column": 3,
-                    "ending_column": 22
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 1769,
-                            "length": 222,
-                            "filename_relative": "contracts/art-token/ArtToken.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                            "filename_short": "contracts/art-token/ArtToken.sol",
-                            "is_dependency": false,
-                            "lines": [55, 56, 57, 58, 59, 60],
-                            "starting_column": 7,
-                            "ending_column": 21
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "ArtToken",
-                                "source_mapping": {
-                                    "start": 580,
-                                    "length": 4112,
-                                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                                    "filename_short": "contracts/art-token/ArtToken.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                                        45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-                                        75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-                                        90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-                                        104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                                        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
-                                        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138
-                                    ],
-                                    "starting_column": 89,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "constructor(address,address,address,IERC20)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "ArtToken.constructor(address,address,address,IERC20).platform (contracts/art-token/ArtToken.sol#56) lacks a zero-check on :\n\t\t- PLATFORM = platform (contracts/art-token/ArtToken.sol#58)\n",
-        "markdown": "[ArtToken.constructor(address,address,address,IERC20).platform](contracts/art-token/ArtToken.sol#L56) lacks a zero-check on :\n\t\t- [PLATFORM = platform](contracts/art-token/ArtToken.sol#L58)\n",
-        "first_markdown_element": "contracts/art-token/ArtToken.sol#L56",
-        "id": "f192d95e290caeecfaed361c27dca64cbafba31a0ecc481c7cd3ce4a5065a07b",
-        "check": "missing-zero-check",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "variable",
-                "name": "auctionHouse",
-                "source_mapping": {
-                    "start": 1814,
-                    "length": 20,
-                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                    "filename_short": "contracts/art-token/ArtToken.sol",
-                    "is_dependency": false,
-                    "lines": [56],
-                    "starting_column": 44,
-                    "ending_column": 64
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 1769,
-                            "length": 222,
-                            "filename_relative": "contracts/art-token/ArtToken.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                            "filename_short": "contracts/art-token/ArtToken.sol",
-                            "is_dependency": false,
-                            "lines": [55, 56, 57, 58, 59, 60],
-                            "starting_column": 7,
-                            "ending_column": 21
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "ArtToken",
-                                "source_mapping": {
-                                    "start": 580,
-                                    "length": 4112,
-                                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                                    "filename_short": "contracts/art-token/ArtToken.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                                        45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-                                        75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-                                        90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-                                        104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                                        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
-                                        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138
-                                    ],
-                                    "starting_column": 89,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "constructor(address,address,address,IERC20)"
-                        }
-                    }
-                }
-            },
-            {
-                "type": "node",
-                "name": "AUCTION_HOUSE = auctionHouse",
-                "source_mapping": {
-                    "start": 1935,
-                    "length": 28,
-                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                    "filename_short": "contracts/art-token/ArtToken.sol",
-                    "is_dependency": false,
-                    "lines": [59],
-                    "starting_column": 3,
-                    "ending_column": 31
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 1769,
-                            "length": 222,
-                            "filename_relative": "contracts/art-token/ArtToken.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                            "filename_short": "contracts/art-token/ArtToken.sol",
-                            "is_dependency": false,
-                            "lines": [55, 56, 57, 58, 59, 60],
-                            "starting_column": 7,
-                            "ending_column": 21
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "ArtToken",
-                                "source_mapping": {
-                                    "start": 580,
-                                    "length": 4112,
-                                    "filename_relative": "contracts/art-token/ArtToken.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
-                                    "filename_short": "contracts/art-token/ArtToken.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-                                        45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-                                        75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
-                                        90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-                                        104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                                        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127,
-                                        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138
-                                    ],
-                                    "starting_column": 89,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "constructor(address,address,address,IERC20)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "ArtToken.constructor(address,address,address,IERC20).auctionHouse (contracts/art-token/ArtToken.sol#56) lacks a zero-check on :\n\t\t- AUCTION_HOUSE = auctionHouse (contracts/art-token/ArtToken.sol#59)\n",
-        "markdown": "[ArtToken.constructor(address,address,address,IERC20).auctionHouse](contracts/art-token/ArtToken.sol#L56) lacks a zero-check on :\n\t\t- [AUCTION_HOUSE = auctionHouse](contracts/art-token/ArtToken.sol#L59)\n",
-        "first_markdown_element": "contracts/art-token/ArtToken.sol#L56",
-        "id": "eafcccd1a1c28b96c8280d7f79c039f295da55c9a2d935af4594d6f01906c0a9",
-        "check": "missing-zero-check",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "variable",
-                "name": "admin",
-                "source_mapping": {
-                    "start": 3785,
-                    "length": 13,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [131],
-                    "starting_column": 13,
-                    "ending_column": 26
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 3773,
-                            "length": 206,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [131, 132, 133, 134, 135],
-                            "starting_column": 1,
-                            "ending_column": 63
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "AuctionHouse",
-                                "source_mapping": {
-                                    "start": 488,
-                                    "length": 9449,
-                                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-                                        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                                        42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                                        57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-                                        72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-                                        87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
-                                        113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-                                        125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                        137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
-                                        149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
-                                        161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                                        173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
-                                        185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
-                                        197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
-                                        209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-                                        221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-                                        233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
-                                        245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                        257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-                                        269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
-                                        281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                        293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
-                                        305, 306, 307, 308, 309
-                                    ],
-                                    "starting_column": 1,
-                                    "ending_column": 75
-                                }
-                            },
-                            "signature": "constructor(address,address,IArtToken,IERC20)"
-                        }
-                    }
-                }
-            },
-            {
-                "type": "node",
-                "name": "ADMIN = admin",
-                "source_mapping": {
-                    "start": 3886,
-                    "length": 13,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [133],
-                    "starting_column": 26,
-                    "ending_column": 39
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 3773,
-                            "length": 206,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [131, 132, 133, 134, 135],
-                            "starting_column": 1,
-                            "ending_column": 63
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "AuctionHouse",
-                                "source_mapping": {
-                                    "start": 488,
-                                    "length": 9449,
-                                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-                                        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                                        42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                                        57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-                                        72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-                                        87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
-                                        113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-                                        125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                        137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
-                                        149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
-                                        161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                                        173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
-                                        185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
-                                        197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
-                                        209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-                                        221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-                                        233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
-                                        245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                        257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-                                        269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
-                                        281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                        293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
-                                        305, 306, 307, 308, 309
-                                    ],
-                                    "starting_column": 1,
-                                    "ending_column": 75
-                                }
-                            },
-                            "signature": "constructor(address,address,IArtToken,IERC20)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "AuctionHouse.constructor(address,address,IArtToken,IERC20).admin (contracts/auction-house/AuctionHouse.sol#131) lacks a zero-check on :\n\t\t- ADMIN = admin (contracts/auction-house/AuctionHouse.sol#133)\n",
-        "markdown": "[AuctionHouse.constructor(address,address,IArtToken,IERC20).admin](contracts/auction-house/AuctionHouse.sol#L131) lacks a zero-check on :\n\t\t- [ADMIN = admin](contracts/auction-house/AuctionHouse.sol#L133)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L131",
-        "id": "2f52fed7ac75d98a4a5e3f7cc77d9db009205be6c58c372d9a70ef6ec8f3a16b",
-        "check": "missing-zero-check",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "variable",
-                "name": "platform",
-                "source_mapping": {
-                    "start": 3800,
-                    "length": 16,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [131, 132],
-                    "starting_column": 28,
-                    "ending_column": 3
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 3773,
-                            "length": 206,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [131, 132, 133, 134, 135],
-                            "starting_column": 1,
-                            "ending_column": 63
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "AuctionHouse",
-                                "source_mapping": {
-                                    "start": 488,
-                                    "length": 9449,
-                                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-                                        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                                        42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                                        57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-                                        72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-                                        87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
-                                        113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-                                        125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                        137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
-                                        149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
-                                        161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                                        173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
-                                        185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
-                                        197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
-                                        209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-                                        221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-                                        233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
-                                        245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                        257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-                                        269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
-                                        281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                        293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
-                                        305, 306, 307, 308, 309
-                                    ],
-                                    "starting_column": 1,
-                                    "ending_column": 75
-                                }
-                            },
-                            "signature": "constructor(address,address,IArtToken,IERC20)"
-                        }
-                    }
-                }
-            },
-            {
-                "type": "node",
-                "name": "PLATFORM = platform",
-                "source_mapping": {
-                    "start": 3909,
-                    "length": 19,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [134, 135],
-                    "starting_column": 1,
-                    "ending_column": 12
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "constructor",
-                        "source_mapping": {
-                            "start": 3773,
-                            "length": 206,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [131, 132, 133, 134, 135],
-                            "starting_column": 1,
-                            "ending_column": 63
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "AuctionHouse",
-                                "source_mapping": {
-                                    "start": 488,
-                                    "length": 9449,
-                                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-                                        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                                        42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                                        57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-                                        72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-                                        87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
-                                        113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-                                        125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                        137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
-                                        149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
-                                        161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                                        173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
-                                        185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
-                                        197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
-                                        209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-                                        221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-                                        233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
-                                        245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                        257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-                                        269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
-                                        281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                        293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
-                                        305, 306, 307, 308, 309
-                                    ],
-                                    "starting_column": 1,
-                                    "ending_column": 75
-                                }
-                            },
-                            "signature": "constructor(address,address,IArtToken,IERC20)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "AuctionHouse.constructor(address,address,IArtToken,IERC20).platform (contracts/auction-house/AuctionHouse.sol#131-132) lacks a zero-check on :\n\t\t- PLATFORM = platform (contracts/auction-house/AuctionHouse.sol#134-135)\n",
-        "markdown": "[AuctionHouse.constructor(address,address,IArtToken,IERC20).platform](contracts/auction-house/AuctionHouse.sol#L131-L132) lacks a zero-check on :\n\t\t- [PLATFORM = platform](contracts/auction-house/AuctionHouse.sol#L134-L135)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L131-L132",
-        "id": "ca7727b74c8f1f16f043909801a41dd97c5b77746d43e62d272f1ad8b7f32f39",
-        "check": "missing-zero-check",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "variable",
-                "name": "admin",
-                "source_mapping": {
-                    "start": 3933,
-                    "length": 13,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [135],
                     "starting_column": 17,
                     "ending_column": 30
                 },
@@ -735,13 +20,279 @@
                         "type": "function",
                         "name": "constructor",
                         "source_mapping": {
-                            "start": 3921,
+                            "start": 1856,
+                            "length": 228,
+                            "filename_relative": "contracts/art-token/ArtToken.sol",
+                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                            "filename_short": "contracts/art-token/ArtToken.sol",
+                            "is_dependency": false,
+                            "lines": [57, 58, 59, 60, 61, 62],
+                            "starting_column": 5,
+                            "ending_column": 6
+                        },
+                        "type_specific_fields": {
+                            "parent": {
+                                "type": "contract",
+                                "name": "ArtToken",
+                                "source_mapping": {
+                                    "start": 652,
+                                    "length": 4431,
+                                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                                    "filename_short": "contracts/art-token/ArtToken.sol",
+                                    "is_dependency": false,
+                                    "lines": [
+                                        18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+                                        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+                                        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+                                        63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+                                        78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+                                        93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+                                        106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+                                        118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+                                        130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141,
+                                        142, 143, 144, 145, 146, 147, 148, 149, 150, 151
+                                    ],
+                                    "starting_column": 1,
+                                    "ending_column": 2
+                                }
+                            },
+                            "signature": "constructor(address,address,IAuctionHouse,IERC20)"
+                        }
+                    }
+                }
+            },
+            {
+                "type": "node",
+                "name": "ADMIN = admin",
+                "source_mapping": {
+                    "start": 1976,
+                    "length": 13,
+                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                    "filename_short": "contracts/art-token/ArtToken.sol",
+                    "is_dependency": false,
+                    "lines": [58],
+                    "starting_column": 9,
+                    "ending_column": 22
+                },
+                "type_specific_fields": {
+                    "parent": {
+                        "type": "function",
+                        "name": "constructor",
+                        "source_mapping": {
+                            "start": 1856,
+                            "length": 228,
+                            "filename_relative": "contracts/art-token/ArtToken.sol",
+                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                            "filename_short": "contracts/art-token/ArtToken.sol",
+                            "is_dependency": false,
+                            "lines": [57, 58, 59, 60, 61, 62],
+                            "starting_column": 5,
+                            "ending_column": 6
+                        },
+                        "type_specific_fields": {
+                            "parent": {
+                                "type": "contract",
+                                "name": "ArtToken",
+                                "source_mapping": {
+                                    "start": 652,
+                                    "length": 4431,
+                                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                                    "filename_short": "contracts/art-token/ArtToken.sol",
+                                    "is_dependency": false,
+                                    "lines": [
+                                        18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+                                        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+                                        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+                                        63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+                                        78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+                                        93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+                                        106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+                                        118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+                                        130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141,
+                                        142, 143, 144, 145, 146, 147, 148, 149, 150, 151
+                                    ],
+                                    "starting_column": 1,
+                                    "ending_column": 2
+                                }
+                            },
+                            "signature": "constructor(address,address,IAuctionHouse,IERC20)"
+                        }
+                    }
+                }
+            }
+        ],
+        "description": "ArtToken.constructor(address,address,IAuctionHouse,IERC20).admin (contracts/art-token/ArtToken.sol#57) lacks a zero-check on :\n\t\t- ADMIN = admin (contracts/art-token/ArtToken.sol#58)\n",
+        "markdown": "[ArtToken.constructor(address,address,IAuctionHouse,IERC20).admin](contracts/art-token/ArtToken.sol#L57) lacks a zero-check on :\n\t\t- [ADMIN = admin](contracts/art-token/ArtToken.sol#L58)\n",
+        "first_markdown_element": "contracts/art-token/ArtToken.sol#L57",
+        "id": "c1acec4f9edc4bb668c41b2098fbdbd482e972dcd045f2d08a2d5e9be15c87b4",
+        "check": "missing-zero-check",
+        "impact": "Low",
+        "confidence": "Medium"
+    },
+    {
+        "elements": [
+            {
+                "type": "variable",
+                "name": "platform",
+                "source_mapping": {
+                    "start": 1883,
+                    "length": 16,
+                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                    "filename_short": "contracts/art-token/ArtToken.sol",
+                    "is_dependency": false,
+                    "lines": [57],
+                    "starting_column": 32,
+                    "ending_column": 48
+                },
+                "type_specific_fields": {
+                    "parent": {
+                        "type": "function",
+                        "name": "constructor",
+                        "source_mapping": {
+                            "start": 1856,
+                            "length": 228,
+                            "filename_relative": "contracts/art-token/ArtToken.sol",
+                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                            "filename_short": "contracts/art-token/ArtToken.sol",
+                            "is_dependency": false,
+                            "lines": [57, 58, 59, 60, 61, 62],
+                            "starting_column": 5,
+                            "ending_column": 6
+                        },
+                        "type_specific_fields": {
+                            "parent": {
+                                "type": "contract",
+                                "name": "ArtToken",
+                                "source_mapping": {
+                                    "start": 652,
+                                    "length": 4431,
+                                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                                    "filename_short": "contracts/art-token/ArtToken.sol",
+                                    "is_dependency": false,
+                                    "lines": [
+                                        18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+                                        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+                                        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+                                        63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+                                        78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+                                        93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+                                        106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+                                        118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+                                        130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141,
+                                        142, 143, 144, 145, 146, 147, 148, 149, 150, 151
+                                    ],
+                                    "starting_column": 1,
+                                    "ending_column": 2
+                                }
+                            },
+                            "signature": "constructor(address,address,IAuctionHouse,IERC20)"
+                        }
+                    }
+                }
+            },
+            {
+                "type": "node",
+                "name": "PLATFORM = platform",
+                "source_mapping": {
+                    "start": 1999,
+                    "length": 19,
+                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                    "filename_short": "contracts/art-token/ArtToken.sol",
+                    "is_dependency": false,
+                    "lines": [59],
+                    "starting_column": 9,
+                    "ending_column": 28
+                },
+                "type_specific_fields": {
+                    "parent": {
+                        "type": "function",
+                        "name": "constructor",
+                        "source_mapping": {
+                            "start": 1856,
+                            "length": 228,
+                            "filename_relative": "contracts/art-token/ArtToken.sol",
+                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                            "filename_short": "contracts/art-token/ArtToken.sol",
+                            "is_dependency": false,
+                            "lines": [57, 58, 59, 60, 61, 62],
+                            "starting_column": 5,
+                            "ending_column": 6
+                        },
+                        "type_specific_fields": {
+                            "parent": {
+                                "type": "contract",
+                                "name": "ArtToken",
+                                "source_mapping": {
+                                    "start": 652,
+                                    "length": 4431,
+                                    "filename_relative": "contracts/art-token/ArtToken.sol",
+                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/art-token/ArtToken.sol",
+                                    "filename_short": "contracts/art-token/ArtToken.sol",
+                                    "is_dependency": false,
+                                    "lines": [
+                                        18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+                                        33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+                                        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+                                        63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77,
+                                        78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+                                        93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+                                        106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+                                        118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129,
+                                        130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141,
+                                        142, 143, 144, 145, 146, 147, 148, 149, 150, 151
+                                    ],
+                                    "starting_column": 1,
+                                    "ending_column": 2
+                                }
+                            },
+                            "signature": "constructor(address,address,IAuctionHouse,IERC20)"
+                        }
+                    }
+                }
+            }
+        ],
+        "description": "ArtToken.constructor(address,address,IAuctionHouse,IERC20).platform (contracts/art-token/ArtToken.sol#57) lacks a zero-check on :\n\t\t- PLATFORM = platform (contracts/art-token/ArtToken.sol#59)\n",
+        "markdown": "[ArtToken.constructor(address,address,IAuctionHouse,IERC20).platform](contracts/art-token/ArtToken.sol#L57) lacks a zero-check on :\n\t\t- [PLATFORM = platform](contracts/art-token/ArtToken.sol#L59)\n",
+        "first_markdown_element": "contracts/art-token/ArtToken.sol#L57",
+        "id": "712c2c74ca94b22610c35392c059b17928dad6ae6bbbef788a0cf0dc81f73947",
+        "check": "missing-zero-check",
+        "impact": "Low",
+        "confidence": "Medium"
+    },
+    {
+        "elements": [
+            {
+                "type": "variable",
+                "name": "admin",
+                "source_mapping": {
+                    "start": 3834,
+                    "length": 13,
+                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
+                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
+                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
+                    "is_dependency": false,
+                    "lines": [133],
+                    "starting_column": 17,
+                    "ending_column": 30
+                },
+                "type_specific_fields": {
+                    "parent": {
+                        "type": "function",
+                        "name": "constructor",
+                        "source_mapping": {
+                            "start": 3822,
                             "length": 206,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
-                            "lines": [135, 136, 137, 138, 139, 140],
+                            "lines": [133, 134, 135, 136, 137, 138],
                             "starting_column": 5,
                             "ending_column": 6
                         },
@@ -751,7 +302,7 @@
                                 "name": "AuctionHouse",
                                 "source_mapping": {
                                     "start": 636,
-                                    "length": 9449,
+                                    "length": 11054,
                                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
@@ -780,7 +331,12 @@
                                         273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
                                         285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
                                         297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                        309, 310, 311, 312, 313, 314, 315, 316
+                                        309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+                                        321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332,
+                                        333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344,
+                                        345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+                                        357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368,
+                                        369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379
                                     ],
                                     "starting_column": 1,
                                     "ending_column": 2
@@ -795,13 +351,13 @@
                 "type": "node",
                 "name": "ADMIN = admin",
                 "source_mapping": {
-                    "start": 4034,
+                    "start": 3935,
                     "length": 13,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [136],
+                    "lines": [134],
                     "starting_column": 9,
                     "ending_column": 22
                 },
@@ -810,13 +366,13 @@
                         "type": "function",
                         "name": "constructor",
                         "source_mapping": {
-                            "start": 3921,
+                            "start": 3822,
                             "length": 206,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
-                            "lines": [135, 136, 137, 138, 139, 140],
+                            "lines": [133, 134, 135, 136, 137, 138],
                             "starting_column": 5,
                             "ending_column": 6
                         },
@@ -826,7 +382,7 @@
                                 "name": "AuctionHouse",
                                 "source_mapping": {
                                     "start": 636,
-                                    "length": 9449,
+                                    "length": 11054,
                                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
@@ -855,7 +411,12 @@
                                         273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
                                         285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
                                         297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                        309, 310, 311, 312, 313, 314, 315, 316
+                                        309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+                                        321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332,
+                                        333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344,
+                                        345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+                                        357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368,
+                                        369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379
                                     ],
                                     "starting_column": 1,
                                     "ending_column": 2
@@ -867,10 +428,10 @@
                 }
             }
         ],
-        "description": "AuctionHouse.constructor(address,address,IArtToken,IERC20).admin (contracts/auction-house/AuctionHouse.sol#135) lacks a zero-check on :\n\t\t- ADMIN = admin (contracts/auction-house/AuctionHouse.sol#136)\n",
-        "markdown": "[AuctionHouse.constructor(address,address,IArtToken,IERC20).admin](contracts/auction-house/AuctionHouse.sol#L135) lacks a zero-check on :\n\t\t- [ADMIN = admin](contracts/auction-house/AuctionHouse.sol#L136)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L135",
-        "id": "f8267620907351d3b927fae05d56f7fb585ef5abf8a22c02be66e1adc81543e5",
+        "description": "AuctionHouse.constructor(address,address,IArtToken,IERC20).admin (contracts/auction-house/AuctionHouse.sol#133) lacks a zero-check on :\n\t\t- ADMIN = admin (contracts/auction-house/AuctionHouse.sol#134)\n",
+        "markdown": "[AuctionHouse.constructor(address,address,IArtToken,IERC20).admin](contracts/auction-house/AuctionHouse.sol#L133) lacks a zero-check on :\n\t\t- [ADMIN = admin](contracts/auction-house/AuctionHouse.sol#L134)\n",
+        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L133",
+        "id": "4742db6f946f6a8d460d2a2e487b0fa76d25ac83a3d992ff375976910ab09f93",
         "check": "missing-zero-check",
         "impact": "Low",
         "confidence": "Medium"
@@ -881,13 +442,13 @@
                 "type": "variable",
                 "name": "platform",
                 "source_mapping": {
-                    "start": 3948,
+                    "start": 3849,
                     "length": 16,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [135],
+                    "lines": [133],
                     "starting_column": 32,
                     "ending_column": 48
                 },
@@ -896,13 +457,13 @@
                         "type": "function",
                         "name": "constructor",
                         "source_mapping": {
-                            "start": 3921,
+                            "start": 3822,
                             "length": 206,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
-                            "lines": [135, 136, 137, 138, 139, 140],
+                            "lines": [133, 134, 135, 136, 137, 138],
                             "starting_column": 5,
                             "ending_column": 6
                         },
@@ -912,7 +473,7 @@
                                 "name": "AuctionHouse",
                                 "source_mapping": {
                                     "start": 636,
-                                    "length": 9449,
+                                    "length": 11054,
                                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
@@ -941,7 +502,12 @@
                                         273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
                                         285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
                                         297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                        309, 310, 311, 312, 313, 314, 315, 316
+                                        309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+                                        321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332,
+                                        333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344,
+                                        345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+                                        357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368,
+                                        369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379
                                     ],
                                     "starting_column": 1,
                                     "ending_column": 2
@@ -956,13 +522,13 @@
                 "type": "node",
                 "name": "PLATFORM = platform",
                 "source_mapping": {
-                    "start": 4057,
+                    "start": 3958,
                     "length": 19,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [137],
+                    "lines": [135],
                     "starting_column": 9,
                     "ending_column": 28
                 },
@@ -971,13 +537,13 @@
                         "type": "function",
                         "name": "constructor",
                         "source_mapping": {
-                            "start": 3921,
+                            "start": 3822,
                             "length": 206,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
-                            "lines": [135, 136, 137, 138, 139, 140],
+                            "lines": [133, 134, 135, 136, 137, 138],
                             "starting_column": 5,
                             "ending_column": 6
                         },
@@ -987,7 +553,7 @@
                                 "name": "AuctionHouse",
                                 "source_mapping": {
                                     "start": 636,
-                                    "length": 9449,
+                                    "length": 11054,
                                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
@@ -1016,7 +582,12 @@
                                         273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
                                         285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
                                         297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                        309, 310, 311, 312, 313, 314, 315, 316
+                                        309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+                                        321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332,
+                                        333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344,
+                                        345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+                                        357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368,
+                                        369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379
                                     ],
                                     "starting_column": 1,
                                     "ending_column": 2
@@ -1028,10 +599,10 @@
                 }
             }
         ],
-        "description": "AuctionHouse.constructor(address,address,IArtToken,IERC20).platform (contracts/auction-house/AuctionHouse.sol#135) lacks a zero-check on :\n\t\t- PLATFORM = platform (contracts/auction-house/AuctionHouse.sol#137)\n",
-        "markdown": "[AuctionHouse.constructor(address,address,IArtToken,IERC20).platform](contracts/auction-house/AuctionHouse.sol#L135) lacks a zero-check on :\n\t\t- [PLATFORM = platform](contracts/auction-house/AuctionHouse.sol#L137)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L135",
-        "id": "37d9cf5bd1684edffb33e6fafdaa684f80e26acb9fdcf1f8edbfc453985a1033",
+        "description": "AuctionHouse.constructor(address,address,IArtToken,IERC20).platform (contracts/auction-house/AuctionHouse.sol#133) lacks a zero-check on :\n\t\t- PLATFORM = platform (contracts/auction-house/AuctionHouse.sol#135)\n",
+        "markdown": "[AuctionHouse.constructor(address,address,IArtToken,IERC20).platform](contracts/auction-house/AuctionHouse.sol#L133) lacks a zero-check on :\n\t\t- [PLATFORM = platform](contracts/auction-house/AuctionHouse.sol#L135)\n",
+        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L133",
+        "id": "f49bf5045d315a673320fb99c5f837a219e9fcd162dc7f46060cc199141304da",
         "check": "missing-zero-check",
         "impact": "Low",
         "confidence": "Medium"
@@ -1042,53 +613,58 @@
                 "type": "function",
                 "name": "_auctionEnded",
                 "source_mapping": {
-                    "start": 8405,
-                    "length": 244,
+                    "start": 9360,
+                    "length": 219,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [263, 264, 265, 266, 267, 268, 269, 270, 271],
-                    "starting_column": 47,
-                    "ending_column": 101
+                    "lines": [305, 306, 307, 308, 309],
+                    "starting_column": 5,
+                    "ending_column": 6
                 },
                 "type_specific_fields": {
                     "parent": {
                         "type": "contract",
                         "name": "AuctionHouse",
                         "source_mapping": {
-                            "start": 488,
-                            "length": 9449,
+                            "start": 636,
+                            "length": 11054,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
                             "lines": [
-                                12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-                                29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-                                46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
-                                63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
-                                97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
-                                111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
-                                124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
-                                150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162,
-                                163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
-                                176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
-                                189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201,
-                                202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214,
-                                215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227,
-                                228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240,
-                                241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253,
-                                254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266,
-                                267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279,
-                                280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305,
-                                306, 307, 308, 309
+                                17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+                                34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+                                68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+                                85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
+                                114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126,
+                                127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+                                140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
+                                153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
+                                166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
+                                179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
+                                192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204,
+                                205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
+                                218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230,
+                                231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243,
+                                244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
+                                257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
+                                270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282,
+                                283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295,
+                                296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
+                                309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
+                                322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334,
+                                335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347,
+                                348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360,
+                                361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373,
+                                374, 375, 376, 377, 378, 379
                             ],
                             "starting_column": 1,
-                            "ending_column": 75
+                            "ending_column": 2
                         }
                     },
                     "signature": "_auctionEnded(uint256)"
@@ -1098,70 +674,75 @@
                 "type": "node",
                 "name": "$.auctions[auctionId].endTime < block.timestamp",
                 "source_mapping": {
-                    "start": 8588,
+                    "start": 9518,
                     "length": 54,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [271],
-                    "starting_column": 40,
-                    "ending_column": 94
+                    "lines": [308],
+                    "starting_column": 9,
+                    "ending_column": 63
                 },
                 "type_specific_fields": {
                     "parent": {
                         "type": "function",
                         "name": "_auctionEnded",
                         "source_mapping": {
-                            "start": 8405,
-                            "length": 244,
+                            "start": 9360,
+                            "length": 219,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
-                            "lines": [263, 264, 265, 266, 267, 268, 269, 270, 271],
-                            "starting_column": 47,
-                            "ending_column": 101
+                            "lines": [305, 306, 307, 308, 309],
+                            "starting_column": 5,
+                            "ending_column": 6
                         },
                         "type_specific_fields": {
                             "parent": {
                                 "type": "contract",
                                 "name": "AuctionHouse",
                                 "source_mapping": {
-                                    "start": 488,
-                                    "length": 9449,
+                                    "start": 636,
+                                    "length": 11054,
                                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                                     "is_dependency": false,
                                     "lines": [
-                                        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-                                        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                                        42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                                        57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-                                        72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-                                        87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
-                                        113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-                                        125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                        137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
-                                        149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
-                                        161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                                        173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
-                                        185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
-                                        197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
-                                        209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-                                        221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-                                        233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
-                                        245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                        257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-                                        269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
-                                        281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                        293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
-                                        305, 306, 307, 308, 309
+                                        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                                        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+                                        47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
+                                        62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+                                        77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+                                        92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+                                        105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+                                        117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128,
+                                        129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
+                                        141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
+                                        153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
+                                        165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176,
+                                        177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
+                                        189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
+                                        201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212,
+                                        213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
+                                        225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236,
+                                        237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248,
+                                        249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260,
+                                        261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272,
+                                        273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
+                                        285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
+                                        297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
+                                        309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+                                        321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332,
+                                        333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344,
+                                        345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+                                        357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368,
+                                        369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379
                                     ],
                                     "starting_column": 1,
-                                    "ending_column": 75
+                                    "ending_column": 2
                                 }
                             },
                             "signature": "_auctionEnded(uint256)"
@@ -1170,10 +751,10 @@
                 }
             }
         ],
-        "description": "AuctionHouse._auctionEnded(uint256) (contracts/auction-house/AuctionHouse.sol#263-271) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- $.auctions[auctionId].endTime < block.timestamp (contracts/auction-house/AuctionHouse.sol#271)\n",
-        "markdown": "[AuctionHouse._auctionEnded(uint256)](contracts/auction-house/AuctionHouse.sol#L263-L271) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [$.auctions[auctionId].endTime < block.timestamp](contracts/auction-house/AuctionHouse.sol#L271)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L263-L271",
-        "id": "d86f6ba7f33c3a40761413a1733fbfb6f02bf940faad2f3d1f46c08f3d69a8a7",
+        "description": "AuctionHouse._auctionEnded(uint256) (contracts/auction-house/AuctionHouse.sol#305-309) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- $.auctions[auctionId].endTime < block.timestamp (contracts/auction-house/AuctionHouse.sol#308)\n",
+        "markdown": "[AuctionHouse._auctionEnded(uint256)](contracts/auction-house/AuctionHouse.sol#L305-L309) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [$.auctions[auctionId].endTime < block.timestamp](contracts/auction-house/AuctionHouse.sol#L308)\n",
+        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L305-L309",
+        "id": "825668a9fba56ee5b531ca75995e4fe046342a28078c168d0743c42a3d265e2c",
         "check": "timestamp",
         "impact": "Low",
         "confidence": "Medium"
@@ -1184,53 +765,58 @@
                 "type": "function",
                 "name": "_requireValidEndTime",
                 "source_mapping": {
-                    "start": 9003,
+                    "start": 10268,
                     "length": 192,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [281, 282, 283, 284, 285, 286, 287, 288, 289],
-                    "starting_column": 64,
-                    "ending_column": 49
+                    "lines": [334, 335, 336, 337, 338],
+                    "starting_column": 5,
+                    "ending_column": 6
                 },
                 "type_specific_fields": {
                     "parent": {
                         "type": "contract",
                         "name": "AuctionHouse",
                         "source_mapping": {
-                            "start": 488,
-                            "length": 9449,
+                            "start": 636,
+                            "length": 11054,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
                             "lines": [
-                                12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-                                29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
-                                46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
-                                63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
-                                97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
-                                111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
-                                124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
-                                150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162,
-                                163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
-                                176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
-                                189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201,
-                                202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214,
-                                215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227,
-                                228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240,
-                                241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253,
-                                254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266,
-                                267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279,
-                                280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305,
-                                306, 307, 308, 309
+                                17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+                                34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+                                51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+                                68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+                                85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+                                101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
+                                114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126,
+                                127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
+                                140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
+                                153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
+                                166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
+                                179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
+                                192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204,
+                                205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
+                                218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230,
+                                231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243,
+                                244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
+                                257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
+                                270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282,
+                                283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295,
+                                296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
+                                309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
+                                322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334,
+                                335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347,
+                                348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360,
+                                361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373,
+                                374, 375, 376, 377, 378, 379
                             ],
                             "starting_column": 1,
-                            "ending_column": 75
+                            "ending_column": 2
                         }
                     },
                     "signature": "_requireValidEndTime(uint256)"
@@ -1240,70 +826,75 @@
                 "type": "node",
                 "name": "endTime <= block.timestamp",
                 "source_mapping": {
-                    "start": 9077,
+                    "start": 10342,
                     "length": 26,
                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                     "is_dependency": false,
-                    "lines": [286, 287],
-                    "starting_column": 2,
-                    "ending_column": 20
+                    "lines": [335],
+                    "starting_column": 13,
+                    "ending_column": 39
                 },
                 "type_specific_fields": {
                     "parent": {
                         "type": "function",
                         "name": "_requireValidEndTime",
                         "source_mapping": {
-                            "start": 9003,
+                            "start": 10268,
                             "length": 192,
                             "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                             "filename_short": "contracts/auction-house/AuctionHouse.sol",
                             "is_dependency": false,
-                            "lines": [281, 282, 283, 284, 285, 286, 287, 288, 289],
-                            "starting_column": 64,
-                            "ending_column": 49
+                            "lines": [334, 335, 336, 337, 338],
+                            "starting_column": 5,
+                            "ending_column": 6
                         },
                         "type_specific_fields": {
                             "parent": {
                                 "type": "contract",
                                 "name": "AuctionHouse",
                                 "source_mapping": {
-                                    "start": 488,
-                                    "length": 9449,
+                                    "start": 636,
+                                    "length": 11054,
                                     "filename_relative": "contracts/auction-house/AuctionHouse.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouse.sol",
                                     "is_dependency": false,
                                     "lines": [
-                                        12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-                                        27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
-                                        42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-                                        57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
-                                        72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-                                        87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                        101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
-                                        113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-                                        125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-                                        137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148,
-                                        149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
-                                        161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172,
-                                        173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184,
-                                        185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196,
-                                        197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208,
-                                        209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-                                        221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232,
-                                        233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
-                                        245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                        257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-                                        269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280,
-                                        281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292,
-                                        293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304,
-                                        305, 306, 307, 308, 309
+                                        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+                                        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+                                        47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
+                                        62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+                                        77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+                                        92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+                                        105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
+                                        117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128,
+                                        129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
+                                        141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
+                                        153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
+                                        165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176,
+                                        177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
+                                        189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
+                                        201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212,
+                                        213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
+                                        225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236,
+                                        237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248,
+                                        249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260,
+                                        261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272,
+                                        273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
+                                        285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
+                                        297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
+                                        309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320,
+                                        321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332,
+                                        333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344,
+                                        345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+                                        357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368,
+                                        369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379
                                     ],
                                     "starting_column": 1,
-                                    "ending_column": 75
+                                    "ending_column": 2
                                 }
                             },
                             "signature": "_requireValidEndTime(uint256)"
@@ -1312,10 +903,10 @@
                 }
             }
         ],
-        "description": "AuctionHouse._requireValidEndTime(uint256) (contracts/auction-house/AuctionHouse.sol#281-289) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- endTime <= block.timestamp (contracts/auction-house/AuctionHouse.sol#286-287)\n",
-        "markdown": "[AuctionHouse._requireValidEndTime(uint256)](contracts/auction-house/AuctionHouse.sol#L281-L289) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [endTime <= block.timestamp](contracts/auction-house/AuctionHouse.sol#L286-L287)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L281-L289",
-        "id": "352ca836108c4742d2bcb45d6f3a5e1a935b91661ac13bd631bafcbaf795d261",
+        "description": "AuctionHouse._requireValidEndTime(uint256) (contracts/auction-house/AuctionHouse.sol#334-338) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- endTime <= block.timestamp (contracts/auction-house/AuctionHouse.sol#335)\n",
+        "markdown": "[AuctionHouse._requireValidEndTime(uint256)](contracts/auction-house/AuctionHouse.sol#L334-L338) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [endTime <= block.timestamp](contracts/auction-house/AuctionHouse.sol#L335)\n",
+        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L334-L338",
+        "id": "6af958ca4a9ac2f128753808148ce9a4a3ca8c366da0e2918eb7b7aaf442f347",
         "check": "timestamp",
         "impact": "Low",
         "confidence": "Medium"
@@ -1431,299 +1022,15 @@
         "elements": [
             {
                 "type": "function",
-                "name": "_auctionEnded",
-                "source_mapping": {
-                    "start": 8553,
-                    "length": 244,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [271, 272, 273, 274, 275],
-                    "starting_column": 5,
-                    "ending_column": 6
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "contract",
-                        "name": "AuctionHouse",
-                        "source_mapping": {
-                            "start": 636,
-                            "length": 9449,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [
-                                17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
-                                34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-                                51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
-                                68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
-                                85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
-                                114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126,
-                                127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-                                140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
-                                153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
-                                166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
-                                179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
-                                192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204,
-                                205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
-                                218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230,
-                                231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243,
-                                244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
-                                270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282,
-                                283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295,
-                                296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                309, 310, 311, 312, 313, 314, 315, 316
-                            ],
-                            "starting_column": 1,
-                            "ending_column": 2
-                        }
-                    },
-                    "signature": "_auctionEnded(uint256)"
-                }
-            },
-            {
-                "type": "node",
-                "name": "$.auctions[auctionId].endTime < block.timestamp",
-                "source_mapping": {
-                    "start": 8736,
-                    "length": 54,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [274],
-                    "starting_column": 9,
-                    "ending_column": 63
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "_auctionEnded",
-                        "source_mapping": {
-                            "start": 8553,
-                            "length": 244,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [271, 272, 273, 274, 275],
-                            "starting_column": 5,
-                            "ending_column": 6
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "AuctionHouse",
-                                "source_mapping": {
-                                    "start": 636,
-                                    "length": 9449,
-                                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                                        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
-                                        47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
-                                        62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
-                                        77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
-                                        92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
-                                        105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
-                                        117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128,
-                                        129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
-                                        141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
-                                        153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
-                                        165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176,
-                                        177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
-                                        189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
-                                        201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212,
-                                        213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
-                                        225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236,
-                                        237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248,
-                                        249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260,
-                                        261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272,
-                                        273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
-                                        285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
-                                        297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                        309, 310, 311, 312, 313, 314, 315, 316
-                                    ],
-                                    "starting_column": 1,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "_auctionEnded(uint256)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "AuctionHouse._auctionEnded(uint256) (contracts/auction-house/AuctionHouse.sol#271-275) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- $.auctions[auctionId].endTime < block.timestamp (contracts/auction-house/AuctionHouse.sol#274)\n",
-        "markdown": "[AuctionHouse._auctionEnded(uint256)](contracts/auction-house/AuctionHouse.sol#L271-L275) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [$.auctions[auctionId].endTime < block.timestamp](contracts/auction-house/AuctionHouse.sol#L274)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L271-L275",
-        "id": "5452a062d6ed11179aa873748d9e09503683334b51584b5343202e62ed967fd3",
-        "check": "timestamp",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "function",
-                "name": "_requireValidEndTime",
-                "source_mapping": {
-                    "start": 9151,
-                    "length": 192,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [289, 290, 291, 292, 293],
-                    "starting_column": 5,
-                    "ending_column": 6
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "contract",
-                        "name": "AuctionHouse",
-                        "source_mapping": {
-                            "start": 636,
-                            "length": 9449,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [
-                                17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
-                                34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-                                51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
-                                68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
-                                85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
-                                101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
-                                114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126,
-                                127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139,
-                                140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
-                                153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165,
-                                166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
-                                179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
-                                192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204,
-                                205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
-                                218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230,
-                                231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243,
-                                244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256,
-                                257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269,
-                                270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282,
-                                283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295,
-                                296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                309, 310, 311, 312, 313, 314, 315, 316
-                            ],
-                            "starting_column": 1,
-                            "ending_column": 2
-                        }
-                    },
-                    "signature": "_requireValidEndTime(uint256)"
-                }
-            },
-            {
-                "type": "node",
-                "name": "endTime <= block.timestamp",
-                "source_mapping": {
-                    "start": 9225,
-                    "length": 26,
-                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                    "is_dependency": false,
-                    "lines": [290],
-                    "starting_column": 13,
-                    "ending_column": 39
-                },
-                "type_specific_fields": {
-                    "parent": {
-                        "type": "function",
-                        "name": "_requireValidEndTime",
-                        "source_mapping": {
-                            "start": 9151,
-                            "length": 192,
-                            "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                            "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                            "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                            "is_dependency": false,
-                            "lines": [289, 290, 291, 292, 293],
-                            "starting_column": 5,
-                            "ending_column": 6
-                        },
-                        "type_specific_fields": {
-                            "parent": {
-                                "type": "contract",
-                                "name": "AuctionHouse",
-                                "source_mapping": {
-                                    "start": 636,
-                                    "length": 9449,
-                                    "filename_relative": "contracts/auction-house/AuctionHouse.sol",
-                                    "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouse.sol",
-                                    "filename_short": "contracts/auction-house/AuctionHouse.sol",
-                                    "is_dependency": false,
-                                    "lines": [
-                                        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-                                        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
-                                        47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
-                                        62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
-                                        77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
-                                        92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
-                                        105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
-                                        117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128,
-                                        129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
-                                        141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
-                                        153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
-                                        165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176,
-                                        177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
-                                        189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
-                                        201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212,
-                                        213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
-                                        225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236,
-                                        237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248,
-                                        249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260,
-                                        261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272,
-                                        273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
-                                        285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296,
-                                        297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308,
-                                        309, 310, 311, 312, 313, 314, 315, 316
-                                    ],
-                                    "starting_column": 1,
-                                    "ending_column": 2
-                                }
-                            },
-                            "signature": "_requireValidEndTime(uint256)"
-                        }
-                    }
-                }
-            }
-        ],
-        "description": "AuctionHouse._requireValidEndTime(uint256) (contracts/auction-house/AuctionHouse.sol#289-293) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- endTime <= block.timestamp (contracts/auction-house/AuctionHouse.sol#290)\n",
-        "markdown": "[AuctionHouse._requireValidEndTime(uint256)](contracts/auction-house/AuctionHouse.sol#L289-L293) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [endTime <= block.timestamp](contracts/auction-house/AuctionHouse.sol#L290)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouse.sol#L289-L293",
-        "id": "b8218f6cce34f7fc59cc0da445a3022b2cc1eff33659381ea6c46c07166bd14f",
-        "check": "timestamp",
-        "impact": "Low",
-        "confidence": "Medium"
-    },
-    {
-        "elements": [
-            {
-                "type": "function",
                 "name": "layout",
                 "source_mapping": {
-                    "start": 701,
+                    "start": 772,
                     "length": 197,
                     "filename_relative": "contracts/auction-house/AuctionHouseStorage.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouseStorage.sol",
                     "filename_short": "contracts/auction-house/AuctionHouseStorage.sol",
                     "is_dependency": false,
-                    "lines": [26, 27, 28, 29, 30, 31, 32, 33],
+                    "lines": [27, 28, 29, 30, 31, 32, 33, 34],
                     "starting_column": 5,
                     "ending_column": 6
                 },
@@ -1733,14 +1040,14 @@
                         "name": "AuctionHouseStorage",
                         "source_mapping": {
                             "start": 246,
-                            "length": 654,
+                            "length": 725,
                             "filename_relative": "contracts/auction-house/AuctionHouseStorage.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouseStorage.sol",
                             "filename_short": "contracts/auction-house/AuctionHouseStorage.sol",
                             "is_dependency": false,
                             "lines": [
                                 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-                                28, 29, 30, 31, 32, 33, 34
+                                28, 29, 30, 31, 32, 33, 34, 35
                             ],
                             "starting_column": 1,
                             "ending_column": 2
@@ -1753,13 +1060,13 @@
                 "type": "node",
                 "name": "",
                 "source_mapping": {
-                    "start": 845,
+                    "start": 916,
                     "length": 47,
                     "filename_relative": "contracts/auction-house/AuctionHouseStorage.sol",
                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouseStorage.sol",
                     "filename_short": "contracts/auction-house/AuctionHouseStorage.sol",
                     "is_dependency": false,
-                    "lines": [30, 31, 32],
+                    "lines": [31, 32, 33],
                     "starting_column": 9,
                     "ending_column": 10
                 },
@@ -1768,13 +1075,13 @@
                         "type": "function",
                         "name": "layout",
                         "source_mapping": {
-                            "start": 701,
+                            "start": 772,
                             "length": 197,
                             "filename_relative": "contracts/auction-house/AuctionHouseStorage.sol",
                             "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouseStorage.sol",
                             "filename_short": "contracts/auction-house/AuctionHouseStorage.sol",
                             "is_dependency": false,
-                            "lines": [26, 27, 28, 29, 30, 31, 32, 33],
+                            "lines": [27, 28, 29, 30, 31, 32, 33, 34],
                             "starting_column": 5,
                             "ending_column": 6
                         },
@@ -1784,14 +1091,14 @@
                                 "name": "AuctionHouseStorage",
                                 "source_mapping": {
                                     "start": 246,
-                                    "length": 654,
+                                    "length": 725,
                                     "filename_relative": "contracts/auction-house/AuctionHouseStorage.sol",
                                     "filename_absolute": "/Users/v.biliy/Documents/work/do/do-contracts/contracts/auction-house/AuctionHouseStorage.sol",
                                     "filename_short": "contracts/auction-house/AuctionHouseStorage.sol",
                                     "is_dependency": false,
                                     "lines": [
                                         11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-                                        26, 27, 28, 29, 30, 31, 32, 33, 34
+                                        26, 27, 28, 29, 30, 31, 32, 33, 34, 35
                                     ],
                                     "starting_column": 1,
                                     "ending_column": 2
@@ -1803,10 +1110,10 @@
                 }
             }
         ],
-        "description": "AuctionHouseStorage.layout() (contracts/auction-house/AuctionHouseStorage.sol#26-33) uses assembly\n\t- INLINE ASM (contracts/auction-house/AuctionHouseStorage.sol#30-32)\n",
-        "markdown": "[AuctionHouseStorage.layout()](contracts/auction-house/AuctionHouseStorage.sol#L26-L33) uses assembly\n\t- [INLINE ASM](contracts/auction-house/AuctionHouseStorage.sol#L30-L32)\n",
-        "first_markdown_element": "contracts/auction-house/AuctionHouseStorage.sol#L26-L33",
-        "id": "cd6cd30744b357f94c3c68cca503829599395afef27eb12f4f18260975cc1b8f",
+        "description": "AuctionHouseStorage.layout() (contracts/auction-house/AuctionHouseStorage.sol#27-34) uses assembly\n\t- INLINE ASM (contracts/auction-house/AuctionHouseStorage.sol#31-33)\n",
+        "markdown": "[AuctionHouseStorage.layout()](contracts/auction-house/AuctionHouseStorage.sol#L27-L34) uses assembly\n\t- [INLINE ASM](contracts/auction-house/AuctionHouseStorage.sol#L31-L33)\n",
+        "first_markdown_element": "contracts/auction-house/AuctionHouseStorage.sol#L27-L34",
+        "id": "7269137036d9609cd8f7f31efb2759060a9541d57d5db49b3553db5dd4485fa3",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"


### PR DESCRIPTION
We may accidentally mint an auctioned token, or start an auction with a minted token, or start multiple auctions for the same token, all of which will result in the auction not being able to end, as the auctioned token will already have been created by the time the auction ends, which will lead to the impossibility of successfully fulfilling the logic of the contract.

Summary:
- Create method `ArtToken::tokenReserved` that returns `true` if a token already is minted;
- Create method `AuctionHouse::tokenReserved` that returns `true` if a token is at an active auction or at an auction with a buyer;
- Add the check that a token is reserved by an auction for method `ArtToken::buy` 
- Add the check that a token is not minted or reserved by another auction for method `AuctionHouse::create` 