### PR TITLE
Add the sender param to the permit for buying

### DIFF
--- a/constants/art-token.ts
+++ b/constants/art-token.ts
@@ -8,6 +8,7 @@ export const BUY_PERMIT_TYPE = {
     BuyPermit: [
         { name: 'tokenId', type: 'uint256' },
         { name: 'tokenURI', type: 'string' },
+        { name: 'sender', type: 'address' },
         { name: 'price', type: 'uint256' },
         { name: 'fee', type: 'uint256' },
         { name: 'participants', type: 'address[]' },

--- a/contracts/art-token/ArtToken.sol
+++ b/contracts/art-token/ArtToken.sol
@@ -24,6 +24,7 @@ contract ArtToken is IArtToken, ArtTokenBase, EIP712 {
             "BuyPermit("
                 "uint256 tokenId,"
                 "string tokenURI,"
+                "address sender,"
                 "uint256 price,"
                 "uint256 fee,"
                 "address[] participants,"
@@ -90,6 +91,7 @@ contract ArtToken is IArtToken, ArtTokenBase, EIP712 {
                 BUY_PERMIT_TYPE_HASH,
                 params.tokenId,
                 keccak256(bytes(params.tokenURI)),
+                msg.sender,
                 params.price,
                 params.fee,
                 keccak256(abi.encodePacked(params.participants)),

--- a/tests/ArtToken.ts
+++ b/tests/ArtToken.ts
@@ -164,6 +164,12 @@ describe('ArtToken', function () {
 
                 await expect(buy({ _deadline })).to.be.rejectedWith('EIP712ExpiredSignature');
             });
+
+            it(`should fail if the sender is wrong`, async () => {
+                const _artToken = artToken.connect(randomAccount);
+
+                await expect(buy({ _artToken })).to.be.rejectedWith('EIP712InvalidSignature');
+            });
         });
 
         describe(`distribution logic`, () => {
@@ -210,6 +216,7 @@ describe('ArtToken', function () {
             params: {
                 _tokenId?: bigint;
                 _tokenURI?: string;
+                _sender?: string;
                 _price?: bigint;
                 _fee?: bigint;
                 _participants?: string[];
@@ -222,6 +229,7 @@ describe('ArtToken', function () {
             const {
                 _tokenId = tokenId,
                 _tokenURI = tokenURI,
+                _sender = buyerAddr,
                 _price = price,
                 _fee = fee,
                 _participants = participants,
@@ -234,6 +242,7 @@ describe('ArtToken', function () {
             const permit: BuyPermitStruct = {
                 tokenId: _tokenId,
                 tokenURI: _tokenURI,
+                sender: _sender,
                 price: _price,
                 fee: _fee,
                 participants: _participants,

--- a/tests/AuctionHouse.ts
+++ b/tests/AuctionHouse.ts
@@ -36,13 +36,12 @@ describe('AuctionHouse', function () {
         [usdc, usdcAddr] = await deployUsdc();
 
         [
-            [proxyAdminOwner, admin, platform, partner, buyer, buyer, randomAccount],
+            [proxyAdminOwner, admin, platform, partner, buyer, randomAccount],
             [
                 proxyAdminOwnerAddr,
                 adminAddr,
                 platformAddr,
                 partnerAddr,
-                buyerAddr,
                 buyerAddr,
                 randomAccountAddr,
             ],
@@ -197,6 +196,7 @@ describe('AuctionHouse', function () {
             const buyPermit: BuyPermitStruct = {
                 tokenId,
                 tokenURI,
+                sender: platformAddr,
                 price: 0n,
                 fee: 0n,
                 participants: [],
@@ -206,7 +206,7 @@ describe('AuctionHouse', function () {
 
             const signature = await signBuyPermit(chainId, artTokenAddr, buyPermit, admin);
 
-            await artToken.buy({
+            await artToken.connect(platform).buy({
                 tokenId,
                 tokenURI,
                 price: buyPermit.price,

--- a/types/art-token.ts
+++ b/types/art-token.ts
@@ -1,6 +1,7 @@
 export type BuyPermitStruct = {
     tokenId: bigint;
     tokenURI: string;
+    sender: string;
     price: bigint;
     fee: bigint;
     participants: string[];


### PR DESCRIPTION
# Issue: Frontrun possible when buying a token.

`ArtToken.sol: buy()`

Method is available for anyone to call in case the correct signature is provided (from the Admin). The signature contains several parameters necessary for the buying. If the signature is valid, the user pays USDC to mint ERC-721 token to his balance. However, the signature doesn’t include the address of the msg.sender (of the actual caller). Thus, when a user sends a transaction with the signature and it appears in the mempool, an attacker is able to see the signature, send the transaction with it and mint the token to his balance instead of the initial user.

### Summary:
- Add the sender param to the permit for buying