### PR TITLE
AuctionHouse - check that buyer is not contract

### DIFF
--- a/contracts/auction-house/AuctionHouse.sol
+++ b/contracts/auction-house/AuctionHouse.sol
@@ -211,6 +211,8 @@ contract AuctionHouse is IAuctionHouse, EIP712 {
 
         _requireValidRaise(price, $.auctions[auctionId].price, 0);
 
+        _requireValidBuyer(msg.sender);
+
         _raise(auctionId, msg.sender, price);
 
         USDC.safeTransferFrom(msg.sender, address(this), price + $.auctions[auctionId].fee);
@@ -234,6 +236,8 @@ contract AuctionHouse is IAuctionHouse, EIP712 {
         address oldBuyer = $.auctions[auctionId].buyer;
 
         _requireValidRaise(price, oldPrice, $.auctions[auctionId].step);
+
+        _requireValidBuyer(msg.sender);
 
         _raise(auctionId, msg.sender, price);
 
@@ -359,6 +363,15 @@ contract AuctionHouse is IAuctionHouse, EIP712 {
     function _requireNotReservedToken(uint256 tokenId) private view {
         if (tokenReserved(tokenId) || TOKEN.tokenReserved(tokenId)) {
             revert AuctionHouseTokenReserved(tokenId);
+        }
+    }
+
+    /**
+     * @dev Throws if the buyer is invalid.
+     */
+    function _requireValidBuyer(address buyer) private view {
+        if (buyer.code.length > 0) {
+            revert AuctionHouseInvalidBuyer(buyer);
         }
     }
 

--- a/contracts/auction-house/IAuctionHouse.sol
+++ b/contracts/auction-house/IAuctionHouse.sol
@@ -116,6 +116,11 @@ interface IAuctionHouse {
     error AuctionHouseBuyerNotExists(uint256 auctionId);
 
     /**
+     * @dev The token buyer is invalid.
+     */
+    error AuctionHouseInvalidBuyer(address buyer);
+
+    /**
      * @dev The auction already exists.
      */
     error AuctionHouseAuctionExists(uint256 auctionId);


### PR DESCRIPTION
# Issue: An auction can get stuck if the high bidder is a contract.

`ArtToken` contract has the check that a token receiver is not a contract, so we can not mint a token for a contract at the end of the auction. This is why we don't use `_safeMint` at the current stage. To avoid an auction getting stuck it needs to add the same check for `AuctionHouse::raise` and `AuctionHouse::raiseInitial` methods. However, we still can not prevent interaction with contracts if the contract performs the operation within its constructor or a token is transferred to a pre-calculated contract address.

### Summary:
- add the check `buyer.code.length > 0` for `AuctionHouse::raiseInitial`
- add the check `buyer.code.length > 0` for `AuctionHouse::raise`